### PR TITLE
Fixes broken "copy to editor" button for css file

### DIFF
--- a/html-css/module-3/index.json
+++ b/html-css/module-3/index.json
@@ -40,7 +40,7 @@
       "text": "finish.md"
     }
   },
-  "files": ["index.html"],
+  "files": ["index.html", "layout.scss"],
   "environment": {
     "showdashboard": true,
     "dashboards": [

--- a/html-css/module-3/step4-instructions.md
+++ b/html-css/module-3/step4-instructions.md
@@ -18,7 +18,7 @@ b. <strong>Copy code to label.html</strong> Click the <strong>Copy to Editor</st
 
 c. <strong>Copy code to label.scss</strong> Click the <strong>Copy to Editor</strong> button below to add CSS for a Label to the layout.scss file.
 
-<pre class="file" data-filename="myapp.scss" data-target="replace">
+<pre class="file" data-filename="layout.scss" data-target="replace">
 <!--Label.scss-->
 .pf-c-label {
 // Component

--- a/html-css/module-3/step4-instructions.md
+++ b/html-css/module-3/step4-instructions.md
@@ -18,7 +18,7 @@ b. <strong>Copy code to label.html</strong> Click the <strong>Copy to Editor</st
 
 c. <strong>Copy code to label.scss</strong> Click the <strong>Copy to Editor</strong> button below to add CSS for a Label to the layout.scss file.
 
-<pre class="file" data-filename="layout.scss" data-target="replace">
+<pre class="file" data-filename="index.html" data-target="replace">
 <!--Label.scss-->
 .pf-c-label {
 // Component

--- a/html-css/module-3/step4-instructions.md
+++ b/html-css/module-3/step4-instructions.md
@@ -18,7 +18,7 @@ b. <strong>Copy code to label.html</strong> Click the <strong>Copy to Editor</st
 
 c. <strong>Copy code to label.scss</strong> Click the <strong>Copy to Editor</strong> button below to add CSS for a Label to the layout.scss file.
 
-<pre class="file" data-filename="index.html" data-target="replace">
+<pre class="file" data-filename="layout.scss" data-target="replace">
 <!--Label.scss-->
 .pf-c-label {
 // Component


### PR DESCRIPTION
"Copy to editor" button now works for CSS in step 4 of module 3