### PR TITLE
Chart CSS verification

### DIFF
--- a/charts/area-chart/index.json
+++ b/charts/area-chart/index.json
@@ -15,7 +15,9 @@
       },
       {
         "title": "Customize with CSS",
-        "text": "step2.md"
+        "text": "step2.md",
+        "verify": "step2-verify.sh",
+        "answer": "step2-answer.md"
       },
       {
         "title": "Create a simple chart",

--- a/charts/area-chart/step2-answer.md
+++ b/charts/area-chart/step2-answer.md
@@ -1,0 +1,8 @@
+Please copy the following code into the app.css file, replacing all of the content there:
+
+<pre class="file" data-filename="src/app.css" data-target="replace">
+.chart-container {
+  height: 250px;
+  width: 600px;
+}
+</pre>

--- a/charts/area-chart/step2-verify.sh
+++ b/charts/area-chart/step2-verify.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+## Ensure user added CSS selector to app.css
+verify() {
+  grep -i "chart-container" ./src/app.css >> /dev/null 2>&1
+  if [ "$?" -eq 0 ]; then
+    echo "done"
+    exit 0
+  fi
+}
+
+verify
+
+## Wait for possible file update and try again
+sleep 3
+verify

--- a/charts/bar-chart/index.json
+++ b/charts/bar-chart/index.json
@@ -15,7 +15,9 @@
       },
       {
         "title": "Customize with CSS",
-        "text": "step2.md"
+        "text": "step2.md",
+        "verify": "step2-verify.sh",
+        "answer": "step2-answer.md"
       },
       {
         "title": "Create a simple chart",

--- a/charts/bar-chart/step2-answer.md
+++ b/charts/bar-chart/step2-answer.md
@@ -1,0 +1,8 @@
+Please copy the following code into the app.css file, replacing all of the content there:
+
+<pre class="file" data-filename="src/app.css" data-target="replace">
+.chart-container {
+  height: 250px;
+  width: 600px;
+}
+</pre>

--- a/charts/bar-chart/step2-verify.sh
+++ b/charts/bar-chart/step2-verify.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+## Ensure user added CSS selector to app.css
+verify() {
+  grep -i "chart-container" ./src/app.css >> /dev/null 2>&1
+  if [ "$?" -eq 0 ]; then
+    echo "done"
+    exit 0
+  fi
+}
+
+verify
+
+## Wait for possible file update and try again
+sleep 3
+verify

--- a/charts/bullet-chart/index.json
+++ b/charts/bullet-chart/index.json
@@ -15,7 +15,9 @@
       },
       {
         "title": "Customize with CSS",
-        "text": "step2.md"
+        "text": "step2.md",
+        "verify": "step2-verify.sh",
+        "answer": "step2-answer.md"
       },
       {
         "title": "Create a simple chart",

--- a/charts/bullet-chart/step2-answer.md
+++ b/charts/bullet-chart/step2-answer.md
@@ -1,0 +1,8 @@
+Please copy the following code into the app.css file, replacing all of the content there:
+
+<pre class="file" data-filename="src/app.css" data-target="replace">
+.chart-container {
+  height: 150px;
+  width: 600px;
+}
+</pre>

--- a/charts/bullet-chart/step2-verify.sh
+++ b/charts/bullet-chart/step2-verify.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+## Ensure user added CSS selector to app.css
+verify() {
+  grep -i "chart-container" ./src/app.css >> /dev/null 2>&1
+  if [ "$?" -eq 0 ]; then
+    echo "done"
+    exit 0
+  fi
+}
+
+verify
+
+## Wait for possible file update and try again
+sleep 3
+verify

--- a/charts/donut-chart/index.json
+++ b/charts/donut-chart/index.json
@@ -15,7 +15,9 @@
       },
       {
         "title": "Customize with CSS",
-        "text": "step2.md"
+        "text": "step2.md",
+        "verify": "step2-verify.sh",
+        "answer": "step2-answer.md"
       },
       {
         "title": "Create a simple chart",

--- a/charts/donut-chart/step2-answer.md
+++ b/charts/donut-chart/step2-answer.md
@@ -1,0 +1,8 @@
+Please copy the following code into the app.css file, replacing all of the content there:
+
+<pre class="file" data-filename="src/app.css" data-target="replace">
+.chart-container {
+  height: 230px;
+  width: 350px;
+}
+</pre>

--- a/charts/donut-chart/step2-verify.sh
+++ b/charts/donut-chart/step2-verify.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+## Ensure user added CSS selector to app.css
+verify() {
+  grep -i "chart-container" ./src/app.css >> /dev/null 2>&1
+  if [ "$?" -eq 0 ]; then
+    echo "done"
+    exit 0
+  fi
+}
+
+verify
+
+## Wait for possible file update and try again
+sleep 3
+verify

--- a/charts/donut-utilization-chart/index.json
+++ b/charts/donut-utilization-chart/index.json
@@ -15,7 +15,9 @@
       },
       {
         "title": "Customize with CSS",
-        "text": "step2.md"
+        "text": "step2.md",
+        "verify": "step2-verify.sh",
+        "answer": "step2-answer.md"
       },
       {
         "title": "Create a simple chart",

--- a/charts/donut-utilization-chart/step2-answer.md
+++ b/charts/donut-utilization-chart/step2-answer.md
@@ -1,0 +1,8 @@
+Please copy the following code into the app.css file, replacing all of the content there:
+
+<pre class="file" data-filename="src/app.css" data-target="replace">
+.chart-container {
+  height: 230px;
+  width: 500px;
+}
+</pre>

--- a/charts/donut-utilization-chart/step2-verify.sh
+++ b/charts/donut-utilization-chart/step2-verify.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+## Ensure user added CSS selector to app.css
+verify() {
+  grep -i "chart-container" ./src/app.css >> /dev/null 2>&1
+  if [ "$?" -eq 0 ]; then
+    echo "done"
+    exit 0
+  fi
+}
+
+verify
+
+## Wait for possible file update and try again
+sleep 3
+verify

--- a/charts/line-chart/index.json
+++ b/charts/line-chart/index.json
@@ -15,7 +15,9 @@
       },
       {
         "title": "Customize with CSS",
-        "text": "step2.md"
+        "text": "step2.md",
+        "verify": "step2-verify.sh",
+        "answer": "step2-answer.md"
       },
       {
         "title": "Create a simple chart",

--- a/charts/line-chart/step2-answer.md
+++ b/charts/line-chart/step2-answer.md
@@ -1,0 +1,8 @@
+Please copy the following code into the app.css file, replacing all of the content there:
+
+<pre class="file" data-filename="src/app.css" data-target="replace">
+.chart-container {
+  height: 250px;
+  width: 600px;
+}
+</pre>

--- a/charts/line-chart/step2-verify.sh
+++ b/charts/line-chart/step2-verify.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+## Ensure user added CSS selector to app.css
+verify() {
+  grep -i "chart-container" ./src/app.css >> /dev/null 2>&1
+  if [ "$?" -eq 0 ]; then
+    echo "done"
+    exit 0
+  fi
+}
+
+verify
+
+## Wait for possible file update and try again
+sleep 3
+verify

--- a/charts/pie-chart/index.json
+++ b/charts/pie-chart/index.json
@@ -15,7 +15,9 @@
       },
       {
         "title": "Customize with CSS",
-        "text": "step2.md"
+        "text": "step2.md",
+        "verify": "step2-verify.sh",
+        "answer": "step2-answer.md"
       },
       {
         "title": "Create a simple chart",

--- a/charts/pie-chart/step2-answer.md
+++ b/charts/pie-chart/step2-answer.md
@@ -1,0 +1,8 @@
+Please copy the following code into the app.css file, replacing all of the content there:
+
+<pre class="file" data-filename="src/app.css" data-target="replace">
+.chart-container {
+  height: 230px;
+  width: 350px;
+}
+</pre>

--- a/charts/pie-chart/step2-verify.sh
+++ b/charts/pie-chart/step2-verify.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+## Ensure user added CSS selector to app.css
+verify() {
+  grep -i "chart-container" ./src/app.css >> /dev/null 2>&1
+  if [ "$?" -eq 0 ]; then
+    echo "done"
+    exit 0
+  fi
+}
+
+verify
+
+## Wait for possible file update and try again
+sleep 3
+verify

--- a/charts/sparkline-chart/index.json
+++ b/charts/sparkline-chart/index.json
@@ -15,7 +15,9 @@
       },
       {
         "title": "Customize with CSS",
-        "text": "step2.md"
+        "text": "step2.md",
+        "verify": "step2-verify.sh",
+        "answer": "step2-answer.md"
       },
       {
         "title": "Create a simple chart",

--- a/charts/sparkline-chart/step2-answer.md
+++ b/charts/sparkline-chart/step2-answer.md
@@ -1,0 +1,13 @@
+Please copy the following code into the app.css file, replacing all of the content there:
+
+<pre class="file" data-filename="src/app.css" data-target="replace">
+.chart-container {
+  height: 100px;
+  width: 400px;
+}
+.chart-label-container {
+  margin-left: 50px;
+  margin-top: 50px;
+  height: 135px;
+}
+</pre>

--- a/charts/sparkline-chart/step2-verify.sh
+++ b/charts/sparkline-chart/step2-verify.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+## Ensure user added CSS selector to app.css
+verify() {
+  grep -ie "chart-container" -ie "chart-label-container" ./src/app.css >> /dev/null 2>&1
+  if [ "$?" -eq 0 ]; then
+    echo "done"
+    exit 0
+  fi
+}
+
+verify
+
+## Wait for possible file update and try again
+sleep 3
+verify

--- a/charts/stack-chart/index.json
+++ b/charts/stack-chart/index.json
@@ -15,7 +15,9 @@
       },
       {
         "title": "Customize with CSS",
-        "text": "step2.md"
+        "text": "step2.md",
+        "verify": "step2-verify.sh",
+        "answer": "step2-answer.md"
       },
       {
         "title": "Create a simple chart",

--- a/charts/stack-chart/step2-answer.md
+++ b/charts/stack-chart/step2-answer.md
@@ -1,0 +1,8 @@
+Please copy the following code into the app.css file, replacing all of the content there:
+
+<pre class="file" data-filename="src/app.css" data-target="replace">
+.chart-container {
+  height: 250px;
+  width: 600px;
+}
+</pre>

--- a/charts/stack-chart/step2-verify.sh
+++ b/charts/stack-chart/step2-verify.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+## Ensure user added CSS selector to app.css
+verify() {
+  grep -i "chart-container" ./src/app.css >> /dev/null 2>&1
+  if [ "$?" -eq 0 ]; then
+    echo "done"
+    exit 0
+  fi
+}
+
+verify
+
+## Wait for possible file update and try again
+sleep 3
+verify


### PR DESCRIPTION
I've introduced a verification step to ensure the user adds CSS to app.css. This is the only step the user cannot skip and have the charts render properly.

I'm using a simple `grep` command in my verification script to check if the app.css file exists and the user has added the expected CSS selector for the chart container. I'm also handling the case where app.css has not been updated due to our 2 sec delay. If the step cannot be verified, we sleep and try once more -- that should be enough time to update the app.css file.

Example: https://katacoda.com/dlabrecq/courses/charts

![chrome-capture(1)](https://user-images.githubusercontent.com/17481322/66523030-e8ae5080-eabc-11e9-8cea-51fe04ee87d4.gif)