### PR TITLE
fix broken links pointing to pf4.patternfly.org to point to www.patternfly.org/v4/

### DIFF
--- a/html-css/module-1/step4-instructions.md
+++ b/html-css/module-1/step4-instructions.md
@@ -26,7 +26,7 @@ Click the <strong>Copy to Editor</strong> button below to add html for a Card co
 
 2) Let's add the bullseye class to the editor so that the Card is centered horizontally and vertically.
 
-<strong>Note: </strong>It’s important to follow the documentation for layouts. Here is a link to the documentation for the Bullseye layout: https://pf4.patternfly.org/layouts/Bullseye/examples/. In the documentation it specifies that you should add the class `pf-l-bullseye` to the parent container of its child.
+<strong>Note: </strong>It’s important to follow the documentation for layouts. Here is a link to the documentation for the Bullseye layout: https://www.patternfly.org/v4/documentation/core/layouts/bullseye. In the documentation it specifies that you should add the class `pf-l-bullseye` to the parent container of its child.
 
 3) On line 1 is the outer `<div>` wrapper. Replace this line with `<div class="pf-l-bullseye">`
 

--- a/html-css/module-3/step2-instructions.md
+++ b/html-css/module-3/step2-instructions.md
@@ -3,7 +3,7 @@ PatternFly is based on the BEM naming system, whereby modifiers are tied to a co
 
 ## Task: Modify the Dropdown for the expanded state, then change the dropdown toggle to the plain variation
 
-In this step we will modify the dropdown component. This is a link to the documentation for the dropdown component. <strong> At the bottom of the page, under the "Usage" section table, you will see the documentation for the modifier classes under “class” and the classes they apply to under “applied”.</strong>  https://pf4.patternfly.org/components/Dropdown/examples/
+In this step we will modify the dropdown component. This is a link to the documentation for the dropdown component. <strong> At the bottom of the page, under the "Usage" section table, you will see the documentation for the modifier classes under “class” and the classes they apply to under “applied”.</strong>  https://www.patternfly.org/v4/documentation/core/components/dropdown
 
 1) <strong>Copy code to the editor.</strong>
 

--- a/html-css/module-3/step3-instructions.md
+++ b/html-css/module-3/step3-instructions.md
@@ -2,9 +2,9 @@ Let’s continue to practice how to add modifier classes to components.
 
 ## Task: Apply visual and state modifiers to the Alert component.
 
-In this workshop we will apply visual modifiers and state modifiers to the same component or element. Using the documentation at this link https://pf4.patternfly.org/components/Alert/examples/, <strong> follow the instructions </strong> to modify the three Alert components.
+In this workshop we will apply visual modifiers and state modifiers to the same component or element. Using the documentation at this link https://www.patternfly.org/v4/documentation/core/components/alert, <strong> follow the instructions </strong> to modify the three Alert components.
 
-1) <strong>Copy code to the editor.</strong> 
+1) <strong>Copy code to the editor.</strong>
 
 Click the <strong>Copy to Editor</strong> button below to add html for three Alert components to the index.html file.
 


### PR DESCRIPTION
I have found some broken links in the training scenarios still pointing to `pf4.patternfly.org`.
The URLs got fixed to point to the newer `www.patternfly.org/v4/` instead.

Two links pointing to `https://pf4.patternfly.org/modifiers` in files `html-css/module-3/finish.md` and `html-css/module-3/step4-instructions.md` didn't get updated as there is no equivalent page in `www.patternfly.org/v4/`.