### PR TITLE
Intro table updates 4

### DIFF
--- a/react-charts/area-chart/step1.md
+++ b/react-charts/area-chart/step1.md
@@ -15,6 +15,6 @@ Copy the following code into the `app.css` file, replacing all the content.
 }
 </pre>
 
-<strong>Note: </strong>Victory renders responsive containers, so the chart's width and height props do not determine the width and height of the chart in number of pixels. Instead, they define an aspect ratio for the chart.
+<strong>Note: </strong>Victory renders responsive containers, so the chart's width and height properties do not determine the width and height of the chart in number of pixels. Instead, they define an aspect ratio for the chart.
 
 The exact number of pixels will depend on the size of the container the chart is rendered into. Typically, the parent container is set to the same width to maintain the aspect ratio.

--- a/react-charts/bar-chart/step1.md
+++ b/react-charts/bar-chart/step1.md
@@ -17,7 +17,7 @@ Copy the following code into the `app.css` file, replacing all of the content th
 </pre>
 
 <strong>Note: </strong>Victory renders responsive containers, so that the chart's
-width and height props do not determine the width and height of the chart in
+width and height properties do not determine the width and height of the chart in
 number of pixels. Instead, they define an aspect ratio for the chart.
 
 The exact number of pixels will depend on the size of the container the chart is

--- a/react-charts/bullet-chart/step1.md
+++ b/react-charts/bullet-chart/step1.md
@@ -15,4 +15,4 @@ Copy the following code into the `app.css` file, replacing all the content:
 }
 </pre>
 
-<strong>Note: </strong>Victory renders responsive containers, so the chart's width and height props do not determine the width and height of the chart in number of pixels. Instead, they define an aspect ratio for the chart. The exact number of pixels will depend on the size of the container the chart is rendered into. Typically, the parent container is set to the same width as the chart to maintain the aspect ratio and scale.
+<strong>Note: </strong>Victory renders responsive containers, so the chart's width and height properties do not determine the width and height of the chart in number of pixels. Instead, they define an aspect ratio for the chart. The exact number of pixels will depend on the size of the container the chart is rendered into. Typically, the parent container is set to the same width as the chart to maintain the aspect ratio and scale.

--- a/react-charts/donut-chart/step1.md
+++ b/react-charts/donut-chart/step1.md
@@ -15,6 +15,6 @@ Copy the following code into the `app.css` file, replacing all of the content.
 }
 </pre>
 
-<strong>Note: </strong>Victory renders responsive containers, so the chart's width and height props do not determine the width and height of the chart in number of pixels. Instead, they define an aspect ratio for the chart.
+<strong>Note: </strong>Victory renders responsive containers, so the chart's width and height properties do not determine the width and height of the chart in number of pixels. Instead, they define an aspect ratio for the chart.
 
 The exact number of pixels will depend on the size of the container the chart is rendered into. Typically, the parent container is set to the same width to maintain the aspect ratio.

--- a/react-charts/donut-utilization-chart/step1.md
+++ b/react-charts/donut-utilization-chart/step1.md
@@ -15,6 +15,6 @@ Copy the following code into the `app.css` file, replacing all of the content.
 }
 </pre>
 
-<strong>Note: </strong>Victory renders responsive containers, so the chart's width and height props do not determine the width and height of the chart in number of pixels. Instead, they define an aspect ratio for the chart.
+<strong>Note: </strong>Victory renders responsive containers, so the chart's width and height properties do not determine the width and height of the chart in number of pixels. Instead, they define an aspect ratio for the chart.
 
 The exact number of pixels will depend on the size of the container the chart is rendered into. Typically, the parent container is set to the same width to maintain the aspect ratio.

--- a/react-charts/line-chart/step1.md
+++ b/react-charts/line-chart/step1.md
@@ -15,7 +15,7 @@ Copy the following code into the `app.css` file, replacing all of the content.
 }
 </pre>
 
-<strong>Note: </strong>Victory renders responsive containers, so the chart's width and height props do not determine the width and height of the chart in number of pixels. Instead, they define an aspect ratio for the chart.
+<strong>Note: </strong>Victory renders responsive containers, so the chart's width and height properties do not determine the width and height of the chart in number of pixels. Instead, they define an aspect ratio for the chart.
 
 The exact number of pixels will depend on the size of the container the chart is rendered into. Typically, the parent container is set to the same width to maintain the aspect ratio.
 

--- a/react-charts/pie-chart/step1.md
+++ b/react-charts/pie-chart/step1.md
@@ -15,6 +15,6 @@ Copy the following code into the `app.css` file, replacing all the content.
 }
 </pre>
 
-<strong>Note: </strong>Victory renders responsive containers, so the chart's width and height props do not determine the width and height of the chart in number of pixels. Instead, they define an aspect ratio for the chart.
+<strong>Note: </strong>Victory renders responsive containers, so the chart's width and height properties do not determine the width and height of the chart in number of pixels. Instead, they define an aspect ratio for the chart.
 
 The exact number of pixels will depend on the size of the container the chart is rendered into. Typically, the parent container is set to the same width to maintain the aspect ratio.

--- a/react-charts/sparkline-chart/step1.md
+++ b/react-charts/sparkline-chart/step1.md
@@ -23,7 +23,7 @@ Copy the following code into the `app.css` file, replacing all the content.
 </pre>
 
 <strong>Note: </strong>Victory renders responsive containers, so the chart's
-width and height props do not determine the width and height of the chart in
+width and height properties do not determine the width and height of the chart in
 number of pixels. Instead, they define an aspect ratio for the chart.
 
 The exact number of pixels will depend on the size of the container the chart is

--- a/react-charts/stack-chart/step1.md
+++ b/react-charts/stack-chart/step1.md
@@ -15,6 +15,6 @@ Copy the following code into the `app.css` file, replacing all the content.
 }
 </pre>
 
-<strong>Note: </strong>Victory renders responsive containers, so the chart's width and height props do not determine the width and height of the chart in number of pixels. Instead, they define an aspect ratio for the chart.
+<strong>Note: </strong>Victory renders responsive containers, so the chart's width and height properties do not determine the width and height of the chart in number of pixels. Instead, they define an aspect ratio for the chart.
 
 The exact number of pixels will depend on the size of the container the chart is rendered into. Typically, the parent container is set to the same width to maintain the aspect ratio.

--- a/react-charts/stack-chart/step4.md
+++ b/react-charts/stack-chart/step4.md
@@ -47,7 +47,7 @@ containerComponent={
 
 5) <strong>Add a `labels` property inside of the `ChartVoronoiContainer`.</strong>
 
-The `containerComponent` prop should look like the following after the `labels` prop is added.
+The `containerComponent` property should look like the following after the `labels` property is added.
 
 <pre class="file" data-target="clipboard">
 containerComponent={

--- a/react-components/table-intro/intro.md
+++ b/react-components/table-intro/intro.md
@@ -1,5 +1,5 @@
-In this scenario, learn how to use PatternFly 4 React table.
+This scenario walks through how to use the PatternFly 4 React table.
 
-PatternFly React tables are based on the [Reactabular.js](https://reactabular.js.org/) library, and extend it with additional functionality and custom components.
+PatternFly React tables are based on the [Reactabular.js](https://reactabular.js.org/) library and extend it with additional functionality.
 
-PatternFly React tables are composed using separate components and composable functions, so features are more easily customizable. This course introduces the PatternFly table package, starting with a basic table component structure, defining simple rows/columns, converting simple row/column definitions into object form, and concluding by incorporating pagination controls.
+PatternFly React tables are composed using separate components and composable functions so that features are more easily customizable. This course introduces the PatternFly table package, starting with a basic table component structure and concluding with incorporating pagination controls.

--- a/react-components/table-intro/step1.md
+++ b/react-components/table-intro/step1.md
@@ -102,4 +102,4 @@ const rowsDefinition = [
 ];
 </pre>
 
-Still have questions? View the latest <a href="https://www.patternfly.org/v4/documentation/react/components/table/" target="_blank">Table documentation</a> for more information.
+Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/documentation/react/components/table/) for more information.

--- a/react-components/table-intro/step1.md
+++ b/react-components/table-intro/step1.md
@@ -7,7 +7,7 @@ The following is an example of what the table component structure looks like:
 &lt;/Table&gt;
 </pre>
 
-Columns can be expressed as an array of strings or an array of objects which match the type "ICell". An "ICell" is a TypeScript interface that represents a cell of the `<Table>`. The columns definition is passed to the `cells` property of the `<Table>` component which can take the form of `Array<ICell | string>`. Below is what the ICell interface looks like.
+Columns can be expressed as an array of strings or an array of objects which match the type "ICell". `ICell` is the name given to the TypeScript interface that represents a cell of the `<Table>`. The columns definition is passed to the `cells` property of the `<Table>` component which can take the form of `Array<ICell | string>`. Below is what the ICell interface looks like.
 
 <pre class="file">
 export interface ICell {
@@ -45,7 +45,7 @@ const columnsDefinition = [
 ];
 </pre>
 
-Rows can be expressed as a multidimensional array of strings or as an array of objects which match the type "IRow". An "IRow" is a TypeScript interface that represents a row of the `<Table>`. The rows definition is passed to the `rows` property of the `<Table>` or `<TableBody>` component, and can take the form of `Array<IRow | string[]>`. Below is what an IRow should look like.
+Rows can be expressed as a multidimensional array of strings or as an array of objects which match the type "IRow". `IRow` is the name given to the TypeScript interface that represents a row of the `<Table>`. The rows definition is passed to the `rows` property of the `<Table>` or `<TableBody>` component, and can take the form of `Array<IRow | string[]>`. Below is what the IRow interface looks like.
 
 <pre class="file">
 export interface IRow extends RowType {

--- a/react-components/table-intro/step1.md
+++ b/react-components/table-intro/step1.md
@@ -7,7 +7,7 @@ The following is an example of what the table component structure looks like:
 &lt;/Table&gt;
 </pre>
 
-Columns can be expressed as an array of strings, or an array of objects which match the type "ICell". The columns definition is passed to the `cells` prop of the Table component which can take the form of `Array<ICell | string>`. Below is what an ICell looks like.
+Columns can be expressed as an array of strings or an array of objects which match the type "ICell". An "ICell" is a TypeScript interface that represents a cell of the `<Table>`. The columns definition is passed to the `cells` property of the `<Table>` component which can take the form of `Array<ICell | string>`. Below is what the ICell interface looks like.
 
 <pre class="file">
 export interface ICell {
@@ -45,7 +45,7 @@ const columnsDefinition = [
 ];
 </pre>
 
-Rows can be expressed as a multidimensional array of strings, or as an array of objects which match the type "IRow". The rows definition is passed to the `rows` prop of the Table or TableBody component, and can take the form of `Array<IRow | string[]>`. Below is what an IRow should look like.
+Rows can be expressed as a multidimensional array of strings or as an array of objects which match the type "IRow". An "IRow" is a TypeScript interface that represents a row of the `<Table>`. The rows definition is passed to the `rows` property of the `<Table>` or `<TableBody>` component, and can take the form of `Array<IRow | string[]>`. Below is what an IRow should look like.
 
 <pre class="file">
 export interface IRow extends RowType {
@@ -101,3 +101,5 @@ const rowsDefinition = [
   }
 ];
 </pre>
+
+Still have questions? View the latest <a href="https://www.patternfly.org/v4/documentation/react/components/table/" target="_blank">Table documentation</a> for more information.

--- a/react-components/table-intro/step2.md
+++ b/react-components/table-intro/step2.md
@@ -1,6 +1,6 @@
-Set up the general structure of the table and add the necessary imports.
-
 Katacoda is setting up a new React application. Begin coding once the server starts and "Welcome to PatternFly" appears on the lower pane.
+
+Set up the general structure of the table and add the necessary imports.
 
 1) <strong>Navigate to the `src` folder and open `src/App.js`.</strong>
 
@@ -38,7 +38,7 @@ const defaultRows = [
 ];
 </pre>
 
-4) <strong>Set the `cells` and `rows` prop for the `<Table />` component.</strong>
+4) <strong>Set the `cells` and `rows` property for the `<Table />` component.</strong>
 
 Locate the `<Table />` component and locate the references to empty arrays (`cells={[]} rows={[]}`). Replace these empty arrays with the row/column definitions that were added in step 3.
 
@@ -49,3 +49,5 @@ cells={columns} rows={defaultRows}
 The table should now look like the image below:
 
 <img src="table-intro/assets/step-2-complete.png" alt="Image of what table looks like at the end of step 2." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
+
+Still have questions? View the latest <a href="https://www.patternfly.org/v4/documentation/react/components/table/" target="_blank">Table documentation</a> for more information.

--- a/react-components/table-intro/step2.md
+++ b/react-components/table-intro/step2.md
@@ -50,4 +50,4 @@ The table should now look like the image below:
 
 <img src="table-intro/assets/step-2-complete.png" alt="Image of what table looks like at the end of step 2." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
 
-Still have questions? View the latest <a href="https://www.patternfly.org/v4/documentation/react/components/table/" target="_blank">Table documentation</a> for more information.
+Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/documentation/react/components/table/) for more information.

--- a/react-components/table-intro/step3.md
+++ b/react-components/table-intro/step3.md
@@ -10,8 +10,10 @@ For each of the columns, set the object's `title` property to the string value u
 
 Apply this transformation to all of the column definitions.
 
-<strong>Note: </strong> The table should appear exactly as it did before:
+The table should visually appear exactly as it did before:
 
 <img src="table-intro/assets/step-3-complete.png" alt="Image of what table looks like at the end of step 3." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
 
-Still have questions? View the latest <a href="https://www.patternfly.org/v4/documentation/react/components/table/" target="_blank">Table documentation</a> for more information.
+Now you can see that column cell definitions can be written as basic strings, or written in object form for more advanced cases. Using object notation here is useful when you need to attach and work with arbitrary data to achieve some custom or dynamic rendering of your column cells.
+
+Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/documentation/react/components/table/) for more information.

--- a/react-components/table-intro/step3.md
+++ b/react-components/table-intro/step3.md
@@ -1,4 +1,4 @@
-With the basic table structure and imports in place, this step will convert the columns definition into an array of objects.
+With the basic table structure and imports in place, convert the columns definition into an array of `ICell` objects.
 
 1) <strong>Locate the table columns definition.</strong>
 
@@ -13,3 +13,5 @@ Apply this transformation to all of the column definitions.
 <strong>Note: </strong> The table should appear exactly as it did before:
 
 <img src="table-intro/assets/step-3-complete.png" alt="Image of what table looks like at the end of step 3." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
+
+Still have questions? View the latest <a href="https://www.patternfly.org/v4/documentation/react/components/table/" target="_blank">Table documentation</a> for more information.

--- a/react-components/table-intro/step4.md
+++ b/react-components/table-intro/step4.md
@@ -1,15 +1,15 @@
 
-1) <strong>Convert each <em>row</em> definition from a string array to an array of objects.</strong>
+1) <strong>Convert each <em>row</em> definition from a string array to an array of `IRow` objects.</strong>
 
 For each of the three row definitions, replace the string array with an object, and set the object's `cells` property to the string array.
 
-It should look like this:
+The three row definitions look like this:
 
 <pre class="file">
 ["Row 1 column 1", "Row 1 column 2", "Row 1 column 3"]
 </pre>
 
-becomes:
+After replacing the string array with an object, the code should look like this:
 
 <pre class="file">
 {
@@ -38,7 +38,7 @@ const defaultRows = [
 
 For each array item in each row's `cells` array, replace the string value with an object whose `title` property is the row cell value.
 
-It should look like this:
+Each array item in each row’s cells array looks like this:
 
 <pre class="file">
 {
@@ -46,7 +46,7 @@ It should look like this:
 }
 </pre>
 
-becomes
+After replacing the string value with an object whose title property is the row cell value, the code should look like this:
 
 <pre class="file">
 {
@@ -65,3 +65,5 @@ Apply this transformation to all of the row cell definitions.
 The table should appear exactly as it did before:
 
 <img src="table-intro/assets/step-4-complete.png" alt="Image of what table looks like at the end of step 4." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
+
+Still have questions? View the latest <a href="https://www.patternfly.org/v4/documentation/react/components/table/" target="_blank">Table documentation</a> for more information.

--- a/react-components/table-intro/step4.md
+++ b/react-components/table-intro/step4.md
@@ -36,17 +36,15 @@ const defaultRows = [
 
 2) <strong>Convert each <em>row cell</em> definition from a string to an object representation.</strong>
 
-For each array item in each row's `cells` array, replace the string value with an object whose `title` property is the row cell value.
+For each array item in each row's `cells` array, replace the string value with an object that has a `title` property equal to the row cell value.
 
-Each array item in each row’s cells array looks like this:
+The array items currently look like this:
 
 <pre class="file">
-{
-  cells: ["Row 1 column 1", "Row 1 column 2", "Row 1 column 3"]
-}
+"Row 1 column 1", "Row 1 column 2", "Row 1 column 3"
 </pre>
 
-After replacing the string value with an object whose title property is the row cell value, the code should look like this:
+After replacing the string array items with objects that have a title property equal to the row cell value, the code should look like this:
 
 <pre class="file">
 {
@@ -62,8 +60,10 @@ Apply this transformation to all of the row cell definitions.
 
 <strong>Note: </strong> String and object definitions can be mixed for the table data.
 
-The table should appear exactly as it did before:
+The table should visually appear exactly as it did before:
 
 <img src="table-intro/assets/step-4-complete.png" alt="Image of what table looks like at the end of step 4." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
 
-Still have questions? View the latest <a href="https://www.patternfly.org/v4/documentation/react/components/table/" target="_blank">Table documentation</a> for more information.
+Now you can see how row cell definitions can be written as basic strings, or written in object form for more advanced cases. Using object notation here is useful when you need to attach and work with arbitrary data to achieve some custom or dynamic rendering of your row cells.
+
+Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/documentation/react/components/table/) for more information.

--- a/react-components/table-intro/step5.md
+++ b/react-components/table-intro/step5.md
@@ -1,8 +1,8 @@
-A typical case for the table component is the need to handle large datasets elegantly. This is addressed on both the styling and interactivity side. In this step, styling techniques are applied to improve the experience.
+Table components are commonly used to handle large datasets. This is addressed on both the styling and interactivity side. In this step, apply styling techniques to improve the experience.
 
 1) <strong>Set the table to compact mode</strong>
 
-Locate the `<Table />` component and add a `variant` <a href="https://reactjs.org/docs/components-and-props.html" target="_blank">prop</a>, setting its value to `compact`.
+Locate the `<Table />` component and add a `variant` <a href="https://reactjs.org/docs/components-and-props.html" target="_blank">property</a>, setting its value to `compact`.
 
 <pre class="file">
 variant="compact"
@@ -11,3 +11,5 @@ variant="compact"
 <strong>Note: </strong> Notice the table head, rows, and cells become compressed and take up less vertical space in order to fit more data on the screen at one time.
 
 <img src="table-intro/assets/step-5-complete.png" alt="Image of what table looks like at the end of step 5." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
+
+Still have questions? View the latest <a href="https://www.patternfly.org/v4/documentation/react/components/table/" target="_blank">Table documentation</a> for more information.

--- a/react-components/table-intro/step5.md
+++ b/react-components/table-intro/step5.md
@@ -1,4 +1,4 @@
-Table components are commonly used to handle large datasets. This is addressed on both the styling and interactivity side. In this step, apply styling techniques to improve the experience.
+Table components are commonly used to handle large datasets. Specialized visual treatment is available for such cases.
 
 1) <strong>Set the table to compact mode</strong>
 
@@ -12,4 +12,4 @@ variant="compact"
 
 <img src="table-intro/assets/step-5-complete.png" alt="Image of what table looks like at the end of step 5." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
 
-Still have questions? View the latest <a href="https://www.patternfly.org/v4/documentation/react/components/table/" target="_blank">Table documentation</a> for more information.
+Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/documentation/react/components/table/) for more information.

--- a/react-components/table-intro/step6.md
+++ b/react-components/table-intro/step6.md
@@ -107,4 +107,4 @@ The table should render the same as it did before, except with a few more rows:
 
 <img src="table-intro/assets/step-6-complete.png" alt="Image of what table looks like at the end of step 6." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
 
-Still have questions? View the latest <a href="https://www.patternfly.org/v4/documentation/react/components/table/" target="_blank">Table documentation</a> for more information.
+Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/documentation/react/components/table/) for more information.

--- a/react-components/table-intro/step6.md
+++ b/react-components/table-intro/step6.md
@@ -1,4 +1,4 @@
-In this step, move the row/column definitions to an external file and adds a few more rows of sample data to make the next part of the lesson more realistic.
+In this step, move the row/column definitions to an external file. Then add a few more rows of sample data.
 
 1) <strong>Navigate to the `src` folder and open `src/data.js`.</strong>
 
@@ -70,7 +70,7 @@ import { columns, defaultRows } from './data';
 
 2) <strong>Delete the rows and columns definitions in `App.js`.</strong>
 
-The table will now use the definitions imported from `data.js` instead. The code to delete looks like the following:
+The table will now use the definitions imported from `data.js` instead. Delete the following code:
 
 <pre class="file">
 const columns = [
@@ -106,3 +106,5 @@ const defaultRows = [
 The table should render the same as it did before, except with a few more rows:
 
 <img src="table-intro/assets/step-6-complete.png" alt="Image of what table looks like at the end of step 6." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
+
+Still have questions? View the latest <a href="https://www.patternfly.org/v4/documentation/react/components/table/" target="_blank">Table documentation</a> for more information.

--- a/react-components/table-intro/step7.md
+++ b/react-components/table-intro/step7.md
@@ -1,4 +1,4 @@
-As mentioned in step 5, tables can be used to handle large datasets on the interaction side. To handle these large datasets, incorporate pagination controls, which give users more granular control over their view of the data. The pagination component is available via PatternFly React core package `@patternfly/react-core`.
+Another way to improve the experience of tables with large datasets is to allow for interactive pagination. The pagination controls give users granular control over their view of the data. The pagination component is available via PatternFly React core package `@patternfly/react-core`.
 
 1) <strong>Import the pagination component.</strong>
 
@@ -26,4 +26,4 @@ itemCount={defaultRows.length}
 
 <img src="table-intro/assets/step-7-complete.png" alt="Image of what table looks like at the end of step 7." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
 
-Still have questions? View the latest <a href="https://www.patternfly.org/v4/documentation/react/components/table/" target="_blank">Table documentation</a> for more information.
+Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/documentation/react/components/table/) for more information.

--- a/react-components/table-intro/step7.md
+++ b/react-components/table-intro/step7.md
@@ -1,4 +1,4 @@
-As mentioned in step 5, the table allows for handling the case of large datasets on the interaction side. Do this by incorporating pagination controls that give users more granular control over their view of the data. The pagination component is available via PatternFly React core package `@patternfly/react-core`.
+As mentioned in step 5, tables can be used to handle large datasets on the interaction side. To handle these large datasets, incorporate pagination controls, which give users more granular control over their view of the data. The pagination component is available via PatternFly React core package `@patternfly/react-core`.
 
 1) <strong>Import the pagination component.</strong>
 
@@ -14,7 +14,7 @@ import { Pagination } from '@patternfly/react-core';
   &lt;Pagination /&gt;
 </pre>
 
-3) <strong>Set the `itemCount` prop of the `<Pagination />` component.</strong>
+3) <strong>Set the `itemCount` property of the `<Pagination />` component.</strong>
 
 Set `itemCount` to the total number of rows in the dataset by referencing the `defaultRows.length`.
 
@@ -22,6 +22,8 @@ Set `itemCount` to the total number of rows in the dataset by referencing the `d
 itemCount={defaultRows.length}
 </pre>
 
-<strong>Note: </strong> Notice the pagination component rendered above the table reflecting 1 - 6 of 6 items. The rendered output should look like the image below:
+<strong>Note: </strong> Notice the pagination component rendered above the table reflecting 1–6 of 6 items. The rendered output should look like this:
 
 <img src="table-intro/assets/step-7-complete.png" alt="Image of what table looks like at the end of step 7." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
+
+Still have questions? View the latest <a href="https://www.patternfly.org/v4/documentation/react/components/table/" target="_blank">Table documentation</a> for more information.

--- a/react-components/table-intro/step8.md
+++ b/react-components/table-intro/step8.md
@@ -1,8 +1,8 @@
-This step adds the state properties needed to track how many rows per page the user can display and what current page the user is on within the dataset. It also introduces a function to handle updating the number of rows per page to show when the user changes this value with the dropdown.
+In this step, add state properties to track how many rows per page the user can display and what current page the user is on within the dataset. Also, introduce a function to handle updating the number of rows per page to show when the user changes this value with the dropdown. IThis tutorial uses the React <a href="https://reactjs.org/docs/hooks-overview.html" target="_blank">hooks api</a>, however you can use a traditional class based approach to achieve the same thing.
 
 1) <strong>Create a state property to track the number of rows to display per page.</strong>
 
-In the `src/App.js` file, just below the line that starts with `const App = () => {`, add the following code to the App component. This code creates a state variable called `numPerPage` and sets the default value to `2`, so that users will see 2 rows per page by default.
+In the `src/App.js` file, just below the line that starts with `const App = () => {`, add the following code to the app component. This code creates a state variable called `numPerPage` and sets the default value to `2` so that users will see 2 rows per page by default.
 
 <pre class="file">
 const defaultPerPage = 2;
@@ -11,9 +11,9 @@ const [numPerPage, setNumPerPage] = React.useState(defaultPerPage);
 
 <strong>Note:</strong> The second parameter in the destructured array returned by React.useState() is the setter for the state variable you're creating. These "setters" are functions that update the corresponding state value.
 
-2) <strong>Set the `perPage` prop of the `<Pagination />` component.</strong>
+2) <strong>Set the `perPage` property of the `<Pagination />` component.</strong>
 
-Set the property to the `numPerPage` state property that was added in step A.
+Set the property to the `numPerPage` state property added in step A.
 
 <pre class="file">
 perPage={numPerPage}
@@ -21,13 +21,13 @@ perPage={numPerPage}
 
 3) <strong>Create a state property to track the current page of the table data.</strong>
 
-Add the following code to the App component, just below the previous state property that was added in step 1. Supply a `1` as the default value so that the table intuitively loads with the first page of data.
+Add the following code to the app component, just below the previous state property added in step 1. Supply a `1` as the default value so that the table intuitively loads with the first page of data.
 
 <pre class="file">
 const [currentPage, setCurrentPage] = React.useState(1);
 </pre>
 
-4) <strong>Set the `page` prop of the `<Pagination />` component to the `currentPage` state property.</strong>
+4) <strong>Set the `page` property of the `<Pagination />` component to the `currentPage` state property.</strong>
 
 <pre class="file">
 page={currentPage}
@@ -35,7 +35,7 @@ page={currentPage}
 
 5) <strong>Set the pagination component dropdown options.</strong>
 
-Set the `perPageOptions` prop of the `<Pagination />` component so that there are two options in the dropdown, 2 and 3. This controls how many rows per page are shown.
+Set the `perPageOptions` property of the `<Pagination />` component so that there are two options in the dropdown, 2 and 3. This controls how many rows per page are shown.
 
 <pre class="file">
 perPageOptions={[{ title: "2", value: 2 }, { title: "3", value: 3 }]}
@@ -47,7 +47,7 @@ perPageOptions={[{ title: "2", value: 2 }, { title: "3", value: 3 }]}
 
 6) <strong>Create a function to handle updating the number of rows per page.</strong>
 
-Add the following code inside the App component definition (just below the state properties added in steps 1 & 3). Inside this function update the `numPerPage` state property to the value selected in the dropdown by calling `setNumPerPage` and passing it the `newPerPage` parameter.
+Add the following code inside the app component definition (just below the state properties added in steps 1 and 3).. Inside this function update the `numPerPage` state property to the value selected in the dropdown by calling `setNumPerPage` and passing it the `newPerPage` parameter.
 
 <pre class="file">
 const handlePerPageSelect = (_evt, newPerPage, newPage = 1, startIdx, endIdx) => {
@@ -55,12 +55,14 @@ const handlePerPageSelect = (_evt, newPerPage, newPage = 1, startIdx, endIdx) =>
 };
 </pre>
 
-7) <strong>Set the `onPerPageSelect` prop of the `<Pagination />` component to the `handlePerPageSelect` function created in step 6.</strong>
+7) <strong>Set the `onPerPageSelect` property of the `<Pagination />` component to the `handlePerPageSelect` function created in step 6.</strong>
 
 <pre class="file">
 onPerPageSelect={handlePerPageSelect}
 </pre>
 
-Here's what the rendered output should look like:
+The rendered output should look like this:
 
 <img src="table-intro/assets/step-8-complete.png" alt="Image of what table looks like at the end of step 8." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
+
+Still have questions? View the latest <a href="https://www.patternfly.org/v4/documentation/react/components/table/" target="_blank">Table documentation</a> for more information.

--- a/react-components/table-intro/step8.md
+++ b/react-components/table-intro/step8.md
@@ -1,4 +1,4 @@
-In this step, add state properties to track how many rows per page the user can display and what current page the user is on within the dataset. Also, introduce a function to handle updating the number of rows per page to show when the user changes this value with the dropdown. IThis tutorial uses the React <a href="https://reactjs.org/docs/hooks-overview.html" target="_blank">hooks api</a>, however you can use a traditional class based approach to achieve the same thing.
+In this step, add state properties to track how many rows per page the user can display and what current page the user is on within the dataset. Also, introduce a function to handle updating the number of rows per page to show when the user changes this value with the dropdown. This tutorial uses the React <a href="https://reactjs.org/docs/hooks-overview.html" target="_blank">hooks api</a>, however you can use a traditional class based approach to achieve the same thing.
 
 1) <strong>Create a state property to track the number of rows to display per page.</strong>
 
@@ -65,4 +65,4 @@ The rendered output should look like this:
 
 <img src="table-intro/assets/step-8-complete.png" alt="Image of what table looks like at the end of step 8." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
 
-Still have questions? View the latest <a href="https://www.patternfly.org/v4/documentation/react/components/table/" target="_blank">Table documentation</a> for more information.
+Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/documentation/react/components/table/) for more information.

--- a/react-components/table-intro/step9.md
+++ b/react-components/table-intro/step9.md
@@ -48,4 +48,4 @@ The table should look like this:
 
 At this point, basic pagination of the table data should be in place. Nice!
 
-Still have questions? View the latest <a href="https://www.patternfly.org/v4/documentation/react/components/table/" target="_blank">Table documentation</a> for more information.
+Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/documentation/react/components/table/) for more information.

--- a/react-components/table-intro/step9.md
+++ b/react-components/table-intro/step9.md
@@ -1,4 +1,4 @@
-Add functionality for paginating the table's dataset. The functionality includes adding a new state property to track the dynamic rows and adding a few more handler functions to facilitate keeping the table and pagination in sync.
+Add functionality for paginating the table's dataset.
 
 1) <strong>Create a new state property to keep track of dynamic rows.</strong>
 
@@ -8,15 +8,15 @@ Add the following code just below the other state properties added in step 8. Se
 const [rows, setRows] = React.useState(defaultRows.slice(0, defaultPerPage));
 </pre>
 
-2) <strong>Update the `<Table />`'s `rows` prop to use the new `rows` state property.</strong>
+2) <strong>Update the `<Table />`'s `rows` property to use the new `rows` state property.</strong>
 
-Locate the code that sets the rows for the table `rows={defaultRows}`, and update it to reference the new rows state property you created in step 1.
+Locate the code that sets the rows for the table `rows={defaultRows}`, and update it to reference the new rows state property created in step 1.
 
 <pre class="file">
 rows={rows}
 </pre>
 
-<strong>Note: </strong> the `itemCount` prop for the pagination component will still reference the defaultRows constant as it needs to be aware of the total number of rows in the entire dataset, not the number of rows that are being shown for a given page within the dataset.
+<strong>Note: </strong> The `itemCount` property for the pagination component will still reference the defaultRows constant. Pagination's `itemCount` property needs to be aware of the total number of rows in the entire dataset, not the number of rows shown for a given page within the dataset.
 
 3) <strong>Create a function to handle updating the current page.</strong>
 
@@ -28,7 +28,7 @@ const handleSetPage = (_evt, newPage, perPage, startIdx, endIdx) => {
 }
 </pre>
 
-4) <strong>Set the `onSetPage` prop of the `<Pagination />` component to the `handleSetPage` handler function.</strong>
+4) <strong>Set the `onSetPage` property of the `<Pagination />` component to the `handleSetPage` handler function.</strong>
 
 <pre class="file">
 onSetPage={handleSetPage}
@@ -42,8 +42,10 @@ Copy the following statement into the `handlePerPageSelect` and `handleSetPage` 
 setRows(defaultRows.slice(startIdx, endIdx));
 </pre>
 
-The table should look like the following:
+The table should look like this:
 
 <img src="table-intro/assets/step-9-complete.png" alt="Image of what table looks like at the end of step 9." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
 
 At this point, basic pagination of the table data should be in place. Nice!
+
+Still have questions? View the latest <a href="https://www.patternfly.org/v4/documentation/react/components/table/" target="_blank">Table documentation</a> for more information.

--- a/react-components/toolbar-filter/step2.md
+++ b/react-components/toolbar-filter/step2.md
@@ -1,4 +1,4 @@
-The individual components placed inside of a toolbar are each wrapped in a `DataToolbarItem` component. `DataToolbarItems` can be passed an optional `variant` prop to format a specific type of component it wraps. These particular components could be a search filter, a pagination component, a bulk select, or an overflow menu. 
+The individual components placed inside of a toolbar are each wrapped in a `DataToolbarItem` component. `DataToolbarItems` can be passed an optional `variant` property to format a specific type of component it wraps. These particular components could be a search filter, a pagination component, a bulk select, or an overflow menu.
 
 Wrapping components in the `DataToolbarItem` component and adding the proper variant ensures the components are spaced appropriately.
 

--- a/react-components/toolbar-filter/step3.md
+++ b/react-components/toolbar-filter/step3.md
@@ -1,6 +1,6 @@
-Toolbar groups are used to group sets of like items to create desired associations and to enable items to respond together to changes in viewport width. A `DataToolbarGroup` passes an optional prop `variant` to format particular types of element groups such as filter groups, button groups, or icon button groups.
+Toolbar groups are used to group sets of like items to create desired associations and to enable items to respond together to changes in viewport width. A `DataToolbarGroup` passes an optional property `variant` to format particular types of element groups such as filter groups, button groups, or icon button groups.
 
-This step will group `DataToolbarItem` components into `DataToolbarGroup` components and apply appropriate `variant` props.
+This step will group `DataToolbarItem` components into `DataToolbarGroup` components and apply appropriate `variant` properties.
 
 1) <strong>Locate the following two `DataToolbarItems` containing `CheckBoxSelect` components:</strong>
 
@@ -25,9 +25,9 @@ This step will group `DataToolbarItem` components into `DataToolbarGroup` compon
 
 2) <strong>Wrap both the `DataToolbarItem` components containing the `CheckboxSelect` filters in one `DataToolbarGroup` component.</strong>
 
-3) <strong>Add the prop `variant="filter-group"` to the `DataToolbarGroup` added in step 2.</strong>
+3) <strong>Add the property `variant="filter-group"` to the `DataToolbarGroup` added in step 2.</strong>
 
-This will space the two `CheckboxSelect` components according to the PatternFly design specifications. 
+This will space the two `CheckboxSelect` components according to the PatternFly design specifications.
 
 Once completed, the code should appear as below.
 
@@ -74,7 +74,7 @@ Once completed, the code should appear as below.
 
 5) <strong>Wrap the three adjacent `DataToolbarItem` components containing icons in one `DataToolbarGroup` component.</strong>
 
-6) <strong>Add the prop `variant="icon-button-group"` to the `DataToolbarGroup` component added in step 5.</strong>
+6) <strong>Add the property `variant="icon-button-group"` to the `DataToolbarGroup` component added in step 5.</strong>
 
 This will space the three icons according to the PatternFly design specifications. Once completed, the code should appear as below.
 

--- a/react-components/toolbar-filter/step5.md
+++ b/react-components/toolbar-filter/step5.md
@@ -2,7 +2,7 @@ One particular type of data toolbar item is called the `DataToolbarFilter`. When
 
 Using a `DataToolbarFilter` requires three properties:
 
-First is a managed array of selected filters called `chips` as strings or ReactNodes. 
+First is a managed array of selected filters called `chips` as strings or ReactNodes.
 
 An `onDelete` callback function to be executed whenever the user deletes a selected filter chip.
 
@@ -91,7 +91,7 @@ Once completed, the contents of the `DataToolbarToggleGroup` should appear as fo
 
 4) <strong>Add a `chips` property to each of the `DataToolbarFilter` components.</strong>
 
-Each of the `DataToolbarFilter` components requires a `chips` property. In this case, the state managed filters array's properties can serve as the `chips` property for each `DataToolbarFilter`. 
+Each of the `DataToolbarFilter` components requires a `chips` property. In this case, the state managed filters array's properties can serve as the `chips` property for each `DataToolbarFilter`.
 
 a) <strong>For the first `DataToolbarFilter` (containing a text input) add the property `chips={filters.name}`.</strong>
 
@@ -137,7 +137,7 @@ Once steps 4, 5, and 6 are completed, the contents of the `DataToolbarToggleGrou
 
 7) <strong>Experiment with two optional properties passed to `DataToolbar`.</strong>
 
-Two props can be optionally added to the top-level `DataToolbar` component when using a `DataToolbarFilter`.
+Two properties can be optionally added to the top-level `DataToolbar` component when using a `DataToolbarFilter`.
 
 a) <strong>Pass a `clearAllFilters` event handler to `DataToolbar`.</strong>
 
@@ -147,7 +147,7 @@ b) <strong>Pass a `collapseListedFiltersBreakpoint` is passed to `DataToolbar`.<
 
 The chip groups will collapse to a summary message at the passed in breakpoint, making the applied filters chip groups more responsive.
 
-Add the following code to the `DataToolbar` to see optional props in action.
+Add the following code to the `DataToolbar` to see optional properties in action.
 
 <pre class="file" data-target="clipboard">
 clearAllFilters={this.onDelete} collapseListedFiltersBreakpoint=&quot;xl&quot;

--- a/react-components/toolbar-filter/step6.md
+++ b/react-components/toolbar-filter/step6.md
@@ -1,12 +1,12 @@
-Managing the relationship of a toolbar and its filters has to a table or other component is the responsibility of the consumer. 
+Managing the relationship of a toolbar and its filters has to a table or other component is the responsibility of the consumer.
 
-1) <strong>Add the `DemoTable` component below the `DataToolbar`.</strong> 
+1) <strong>Add the `DemoTable` component below the `DataToolbar`.</strong>
 
-Pass the `DemoTable` the status and risk filters as props.
+Pass the `DemoTable` the status and risk filters as properties.
 
 <pre class="file" data-target="clipboard">
 &lt;DemoTable nameFilters={filters.name} statusFilters={filters.status} riskFilters={filters.risk} clearAllFilters={this.onDelete}/&gt;
-</pre> 
+</pre>
 
 <strong>Note:</strong> The relationship a toolbar and its filters has to a table or other component must be managed by the consumer. The `DemoTable` component is defined in `src/components/table.js` where the managed list of applied filters manipulates a very small set of data.
 

--- a/react/react-basics/step5.md
+++ b/react/react-basics/step5.md
@@ -21,7 +21,7 @@ Use a split layout to separate a pair of buttons in the footer of the card. The 
 
 2) <strong>Add a button to the first `SplitItem` component.</strong>
 
-Use the `link` variant of the button and add an `isInline` prop so that the buttons are inline rather than block elements.
+Use the `link` variant of the button and add an `isInline` property so that the buttons are inline rather than block elements.
 
 <pre class="file" data-target="clipboard">
 &lt;Button variant=&quot;link&quot; isInline>Link to PatternFly&lt;/Button&gt;
@@ -29,13 +29,13 @@ Use the `link` variant of the button and add an `isInline` prop so that the butt
 
 3) <strong>Add a button to the second `SplitItem` component.</strong>
 
-Use the same variant and props as step 2.
+Use the same variant and properties as step 2.
 
 <pre class="file" data-target="clipboard">
 &lt;Button variant=&quot;link&quot; isInline>Link to home&lt;/Button&gt;
 </pre>
 
-4) <strong>Add a gutter prop to the `Split` component to add more spacing between the buttons.</strong>
+4) <strong>Add a gutter property to the `Split` component to add more spacing between the buttons.</strong>
 
 The `Split` component should look like this with the gutter set to `md` (medium) spacing.
 

--- a/react/react-customize/step3.md
+++ b/react/react-customize/step3.md
@@ -2,7 +2,7 @@ Next modify the cards.
 
 1) <strong>Add a hover effect to the `card` component.</strong>
 
-PatternFly components, including `card`, can be customized with props. Add a hover effect to the cards with the `isHoverable` prop.
+PatternFly components, including `card`, can be customized with properties. Add a hover effect to the cards with the `isHoverable` property.
 
 It should look like this:
 
@@ -14,7 +14,7 @@ It should look like this:
 
 Change the variant to achieve different types of buttons.
 
-Inside the `CardFooter` component, replace the current variant on the button with the `primary` variant, and remove the `isLine` prop.
+Inside the `CardFooter` component, replace the current variant on the button with the `primary` variant, and remove the `isLine` property.
 
 The code should look like the following:
 


### PR DESCRIPTION
This PR applies some updates to the intro-table tutorial in response to recent feedback we've received. It's mostly cleaning up step instruction, but also applies a global change in the way we refer to input properties for react components. Previously we used the short version of "prop" and "props", now we use the full word properties which are a little less likely to be misunderstood.

Should help close https://github.com/patternfly/training-scenarios/issues/270, https://github.com/patternfly/training-scenarios/issues/254 and https://github.com/patternfly/training-scenarios/issues/171. 

https://www.katacoda.com/seanforyou23/courses/react-components/table-intro

Lemme know if you see any issues!