### PR TITLE
Update init scripts for html-css scenarios

### DIFF
--- a/html-css/building-blocks/env-init.sh
+++ b/html-css/building-blocks/env-init.sh
@@ -1,6 +1,5 @@
-curl -L https://raw.githubusercontent.com/patternfly/training-scenarios/master/site/pf-express.tar.gz > ~/pf-express.tar.gz
-tar -xvzf ~/pf-express.tar.gz -C ~/tutorial
-cd ~/tutorial
+curl -L https://raw.githubusercontent.com/patternfly/training-scenarios/master/site/pf-express.tar.gz > /root/pf-express.tar.gz
+tar -xvzf /root/pf-express.tar.gz
 npm install
 echo "Starting... this will block the rest of the commands from running..."
 npm start

--- a/html-css/layouts/env-init.sh
+++ b/html-css/layouts/env-init.sh
@@ -1,6 +1,5 @@
-curl -L https://raw.githubusercontent.com/patternfly/training-scenarios/master/site/pf-express.tar.gz > ~/pf-express.tar.gz
-tar -xvzf ~/pf-express.tar.gz -C ~/tutorial
-cd ~/tutorial
+curl -L https://raw.githubusercontent.com/patternfly/training-scenarios/master/site/pf-express.tar.gz > /root/pf-express.tar.gz
+tar -xvzf /root/pf-express.tar.gz
 npm install
 echo "Starting... this will block the rest of the commands from running..."
 npm start

--- a/html-css/modifier-utilities/env-init.sh
+++ b/html-css/modifier-utilities/env-init.sh
@@ -1,6 +1,5 @@
-curl -L https://raw.githubusercontent.com/patternfly/training-scenarios/master/site/pf-express.tar.gz > ~/pf-express.tar.gz
-tar -xvzf ~/pf-express.tar.gz -C ~/tutorial
-cd ~/tutorial
+curl -L https://raw.githubusercontent.com/patternfly/training-scenarios/master/site/pf-express.tar.gz > /root/pf-express.tar.gz
+tar -xvzf /root/pf-express.tar.gz
 npm install
 echo "Starting... this will block the rest of the commands from running..."
 npm start

--- a/html-css/override-extend-variables/env-init.sh
+++ b/html-css/override-extend-variables/env-init.sh
@@ -1,6 +1,5 @@
-curl -L https://raw.githubusercontent.com/patternfly/training-scenarios/master/site/pf-express.tar.gz > ~/pf-express.tar.gz
-tar -xvzf ~/pf-express.tar.gz -C ~/tutorial
-cd ~/tutorial
+curl -L https://raw.githubusercontent.com/patternfly/training-scenarios/master/site/pf-express.tar.gz > /root/pf-express.tar.gz
+tar -xvzf /root/pf-express.tar.gz
 npm install
 echo "Starting... this will block the rest of the commands from running..."
 npm start

--- a/html-css/variable-naming-principles/env-init.sh
+++ b/html-css/variable-naming-principles/env-init.sh
@@ -1,6 +1,5 @@
-curl -L https://raw.githubusercontent.com/patternfly/training-scenarios/master/site/pf-express.tar.gz > ~/pf-express.tar.gz
-tar -xvzf ~/pf-express.tar.gz -C ~/tutorial
-cd ~/tutorial
+curl -L https://raw.githubusercontent.com/patternfly/training-scenarios/master/site/pf-express.tar.gz > /root/pf-express.tar.gz
+tar -xvzf /root/pf-express.tar.gz
 npm install
 echo "Starting... this will block the rest of the commands from running..."
 npm start


### PR DESCRIPTION
The default directory for the `node` image now has changed to `/root`. This PR contains the changes for the scripts used to initialized the html-css scenarios, similar work is needed for react scenarios.

I've tested with the scenario:
https://katacoda.com/gssg/scenarios/building-blocks

<img width="1617" alt="Screen Shot 2020-06-17 at 11 22 50 PM" src="https://user-images.githubusercontent.com/5870211/84985427-8e589b80-b0f1-11ea-88a9-da18984cf5da.png">


Signed-off-by: Gabriela S. Soria <soria.gaby@gmail.com>