### PR TITLE
fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # PatternFly developer training
 
-PatternFly now features developer training to teach PatternFly implementation best practices. To access the training, check out the (React)[https://www.patternfly.org/v4/documentation/react/overview/training] and (HTML/CSS)[https://www.patternfly.org/v4/documentation/core/overview/training] tutorials. 
+PatternFly now features developer training to teach PatternFly implementation best practices. To access the training, check out the [React](https://www.patternfly.org/v4/training/react) and [HTML/CSS](https://www.patternfly.org/v4/training/html) tutorials. 
 And while you're at it, let us know what you think. Share your feedback by submitting a review on the final page of each module or by filing an issue in this repository.
 
 ## Submitting a proposal
 
-We use (Katacoda)[https://www.katacoda.com/patternfly] as the platform for delivering the training modules—it's open source, and we want you to contribute! 
+We use [Katacoda](https://www.katacoda.com/patternfly) as the platform for delivering the training modules—it's open source, and we want you to contribute! 
 
-But before you add a new module to the current PatternFly developer training set, check out the existing modules in the category first. This way, we avoid duplicate work and keep the training content streamlined and organized for all users. You should also verify that the module expands on the documentation that is already on (PatternFly)[https://www.patternfly.org/v4/].
+But before you add a new module to the current PatternFly developer training set, check out the existing modules in the category first. This way, we avoid duplicate work and keep the training content streamlined and organized for all users. You should also verify that the module expands on the documentation that is already on [PatternFly](https://www.patternfly.org/v4/).
 
 Once you've checked and confirmed the content you're looking to add doesn't already exist, create a new issue for your proposal in this repository. Our team will review all submissions before anything is added.
 
@@ -40,14 +40,14 @@ Once your proposal is approved, it's time to start developing. We recommend foll
 
 To see your changes on Katacoda before they're merged:
 1. Submit a second Pull Request that merges changes from the new branch on your fork, to the master branch on your fork, and merge the changes.
-2. Create a (Katacoda profile)[https://katacoda.com/profile/settings ] if you don’t have one.
+2. Create a [Katacoda profile](https://katacoda.com/profile/settings) if you don’t have one.
     - Update your Git Scenario Repository to be your forked training-scenarios repository (e.g., https://github.com/[username]/training-scenarios).
 3. Copy the **Git Webhook Secret.**
 4. In your forked training-scenarios repository, navigate to **Settings** > **Webhooks**, and add a new Github Webhook.
     - Update the Payload URL to **https://editor.katacoda.com/scenarios/updated**.
     - Add your copied secret.
     - Click **Update webhook**.
-5. Find more information at (Katacoda)[https://katacoda.com/teach/git-hosted-scenarios].
+5. Find more information at [Katacoda](https://katacoda.com/teach/git-hosted-scenarios).
 
 ## File structure
 
@@ -59,7 +59,7 @@ Add an ID, title, and description.
 
 ### Add an index.json file for the module
 
-The `index.json` file is where the structure of the module is established. Below is a template `index.json` file that you should follow. (Katacoda provides more information)[https://www.katacoda.com/docs/scenarios/index-json].
+The `index.json` file is where the structure of the module is established. Below is a template `index.json` file that you should follow. [Katacoda provides more information](https://www.katacoda.com/docs/scenarios/index-json).
 
 ```
 {
@@ -194,7 +194,7 @@ When writing out the steps for your tutorial please follow these guidelines:
 
 ## Style and grammar
 
-We suggest following (AP style)[https://en.wikipedia.org/wiki/AP_Stylebook] when writing content. PatternFly also has more information on (grammar and terminology)[https://www.patternfly.org/v4/design-guidelines/content/grammar-and-terminology] and (voice and tone)[https://www.patternfly.org/v4/design-guidelines/content/voice-and-tone].
+We suggest following [AP style](https://en.wikipedia.org/wiki/AP_Stylebook) when writing content. PatternFly also has more information on [grammar and terminology](https://www.patternfly.org/v4/design-guidelines/content/grammar-and-terminology) and [voice and tone](https://www.patternfly.org/v4/design-guidelines/content/voice-and-tone).
 
 ## Appendix
 

--- a/html-css/building-blocks/step2-instructions.md
+++ b/html-css/building-blocks/step2-instructions.md
@@ -31,4 +31,4 @@ To do this add this block of code between `pf-c-chip__text` and `pf-c-button`.
 </span>
 ```
 
-<strong>Note: </strong> Remember this is a component and not a demo because the chip component includes styles that handle how the badge looks within the chip. For example, when the badge component is added to the chip, it receives styling that gives it a margin. You can read more in the documentation [here](https://www.patternfly.org/v4/documentation/core/components/chip)
+<strong>Note: </strong> Remember this is a component and not a demo because the chip component includes styles that handle how the badge looks within the chip. For example, when the badge component is added to the chip, it receives styling that gives it a margin. You can read more in the documentation [here](https://www.patternfly.org/v4/components/chip)

--- a/html-css/building-blocks/step3-instructions.md
+++ b/html-css/building-blocks/step3-instructions.md
@@ -32,4 +32,4 @@ It should look like: `<div class="pf-l-bullseye">`
 
 Once the preview reloads, the card should be centered in the middle of the page.
 
-<strong>Note: </strong>It’s important to follow the documentation for layouts because it demonstrates where to add the layout class. The [documentation for bullseye](https://www.patternfly.org/v4/documentation/core/layouts/bullseye) specifies to add the class `pf-l-bullseye` to the parent container of its child.
+<strong>Note: </strong>It’s important to follow the documentation for layouts because it demonstrates where to add the layout class. The [documentation for bullseye](https://www.patternfly.org/v4/layouts/bullseye/html) specifies to add the class `pf-l-bullseye` to the parent container of its child.

--- a/html-css/building-blocks/step4-instructions.md
+++ b/html-css/building-blocks/step4-instructions.md
@@ -60,7 +60,7 @@ Add the class `pf-m-gutter` after `pf-l-grid` to the outermost wrapper, inside t
 
 It should look like: `<div class="pf-l-grid pf-m-gutter">`
 
-<strong>Note: </strong> Learn how modifier classes work with layout classes by looking at the [documentation](https://www.patternfly.org/v4/documentation/core/layouts/grid#usage) on the PatternFly website.
+<strong>Note: </strong> Learn how modifier classes work with layout classes by looking at the [documentation](https://www.patternfly.org/v4/layouts/grid/html#usage) on the PatternFly website.
 
 5) <strong>Add modifier classes to the grid item classes.</strong>
 

--- a/html-css/layouts/finish.md
+++ b/html-css/layouts/finish.md
@@ -3,10 +3,10 @@ Congratulations! You finished the "layouts" course.
 [Please fill out a quick survey here](https://redhatdg.co1.qualtrics.com/jfe/form/SV_bIRZRHYJyGsKBSt?Module=htmlcss-module4)
 
 > Learn more about PatternFly Layouts:
->- [Bullseye Layout](https://www.patternfly.org/v4/documentation/core/layouts/bullseye)
->- [Flex Layout](https://www.patternfly.org/v4/documentation/core/layouts/flex)
->- [Gallery Layout](https://www.patternfly.org/v4/documentation/core/layouts/gallery)
->- [Grid Layout](https://www.patternfly.org/v4/documentation/core/layouts/grid)
->- [Level Layout](https://www.patternfly.org/v4/documentation/core/layouts/level)
->- [Split Layout](https://www.patternfly.org/v4/documentation/core/layouts/split)
->- [Stack Layout](https://www.patternfly.org/v4/documentation/core/layouts/stack)
+>- [Bullseye Layout](https://www.patternfly.org/v4/layouts/bullseye)
+>- [Flex Layout](https://www.patternfly.org/v4/layouts/flex)
+>- [Gallery Layout](https://www.patternfly.org/v4/layouts/gallery)
+>- [Grid Layout](https://www.patternfly.org/v4/layouts/grid)
+>- [Level Layout](https://www.patternfly.org/v4/layouts/level)
+>- [Split Layout](https://www.patternfly.org/v4/layouts/split)
+>- [Stack Layout](https://www.patternfly.org/v4/layouts/stack)

--- a/html-css/modifier-utilities/step2-instructions.md
+++ b/html-css/modifier-utilities/step2-instructions.md
@@ -51,4 +51,4 @@ This will style the `pf-c-dropdown__toggle` class to have no border.
 
 It should look like this: `<button class="pf-c-dropdown__toggle pf-m-plain">`
 
-<strong>Note: </strong> Now try adding `pf-m-plain` to `pf-c-dropdown__menu`. Notice that nothing happens. This is because the modifier class does not apply to `pf-c-dropdown__menu`, it only applies to `pf-c-dropdown__toggle`. When applying modifier classes always refer to the [documentation](https://www.patternfly.org/v4/documentation/core/components/dropdown).
+<strong>Note: </strong> Now try adding `pf-m-plain` to `pf-c-dropdown__menu`. Notice that nothing happens. This is because the modifier class does not apply to `pf-c-dropdown__menu`, it only applies to `pf-c-dropdown__toggle`. When applying modifier classes always refer to the [documentation](https://www.patternfly.org/v4/components/dropdown/html).

--- a/html-css/modifier-utilities/step3-instructions.md
+++ b/html-css/modifier-utilities/step3-instructions.md
@@ -35,7 +35,7 @@ Click the `Copy to Editor` button below to add HTML for three alert components.
 
 2) <strong>Modify the first alert to be the `success` variation.</strong>
 
-To find the modifier class, use the [documentation](https://www.patternfly.org/v4/documentation/core/components/alert). Scroll down to the "usage" table and find the class that styles the success variation.
+To find the modifier class, use the [documentation](https://www.patternfly.org/v4/components/alert/html). Scroll down to the "usage" table and find the class that styles the success variation.
 
 When the class is found, add it next to the first `pf-c-alert` class.
 
@@ -43,13 +43,13 @@ It should look like this: `<div class="pf-c-alert pf-m-success">`
 
 3) <strong>Modify the second alert to have `inline` and `warning` variations.</strong>
 
-Use the [documentation](https://www.patternfly.org/v4/documentation/core/components/alert) to find the classes that will modify the alert to have these variations.
+Use the [documentation](https://www.patternfly.org/v4/components/alert/html) to find the classes that will modify the alert to have these variations.
 
 It should look like this: `<div class="pf-c-alert pf-m-inline pf-m-warning">`
 
 4) <strong>Modify the third alert to have `danger` and `info` variations.</strong>
 
-Use the [documentation](https://www.patternfly.org/v4/documentation/core/components/alert) to find the classes that will modify the alert to have these variations.
+Use the [documentation](https://www.patternfly.org/v4/components/alert/html) to find the classes that will modify the alert to have these variations.
 
 It should look like this: `<div class="pf-c-alert pf-m-info pf-m-danger">`
 

--- a/html-css/variable-naming-principles/step1-instructions.md
+++ b/html-css/variable-naming-principles/step1-instructions.md
@@ -51,7 +51,7 @@ In reference to the documentation above, it should be: `--pf-c-alert`
 
 4) <strong>Add the modifier to the custom property name.</strong>
 
-Reference the [documentation](https://www.patternfly.org/v4/documentation/core/components/alert) by scrolling down to the bottom to view the alert component's documentation. Note that the success variation class `.pf-m-success` applies to `.pf-c-alert`. Add that modifier to the custom property.
+Reference the [documentation](https://www.patternfly.org/v4/components/alert/html) by scrolling down to the bottom to view the alert component's documentation. Note that the success variation class `.pf-m-success` applies to `.pf-c-alert`. Add that modifier to the custom property.
 
 The custom property name should now be: `--pf-c-alert--m-success`
 

--- a/react-charts/area-chart/finish.md
+++ b/react-charts/area-chart/finish.md
@@ -3,7 +3,7 @@ Congratulations! You finished the "area chart" course.
 [Please fill out a quick survey here](https://redhatdg.co1.qualtrics.com/jfe/form/SV_bIRZRHYJyGsKBSt?Module=charts-areachart)
 
 > Learn more about PatternFly React:
->- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/developers)
->- [PatternFly React documentation](https://www.patternfly.org/v4/documentation/react/components/)
+>- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/develop)
+>- [PatternFly React documentation](https://www.patternfly.org/v4/components/about-modal)
 >- [PatternFly area chart documentation](https://patternfly-react.surge.sh/patternfly-4/charts/chartarea/)
 >- [Victory chart documentation](https://formidable.com/open-source/victory/docs/victory-chart/)

--- a/react-charts/bar-chart/finish.md
+++ b/react-charts/bar-chart/finish.md
@@ -3,7 +3,7 @@ Congratulations! You finished the "bar chart" course.
 [Please fill out a quick survey here](https://redhatdg.co1.qualtrics.com/jfe/form/SV_bIRZRHYJyGsKBSt?Module=charts-barchart)
 
 > Learn more about PatternFly React:
->- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/developers)
->- [PatternFly React documentation](https://www.patternfly.org/v4/documentation/react/components/)
->- [PatternFly bar chart documentation](https://patternfly-react.surge.sh/patternfly-4/charts/chartbar/)
+>- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/develop)
+>- [PatternFly React documentation](https://www.patternfly.org/v4/charts/about)
+>- [PatternFly bar chart documentation](https://www.patternfly.org/v4/charts/bar-chart)
 >- [Victory chart documentation](https://formidable.com/open-source/victory/docs/victory-chart/)

--- a/react-charts/bullet-chart/finish.md
+++ b/react-charts/bullet-chart/finish.md
@@ -4,7 +4,7 @@ Congratulations! You finished the PatternFly React bullet chart course.
 
 > Learn more about PatternFly React:
 >
-> - [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/developers)
-> - [PatternFly React documentation](https://www.patternfly.org/v4/documentation/react/components/)
-> - [PatternFly bullet chart documentation](https://patternfly-react.surge.sh/patternfly-4/charts/chartbullet/)
+> - [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/develop)
+> - [PatternFly React documentation](https://www.patternfly.org/v4/charts/about)
+> - [PatternFly bullet chart documentation](https://www.patternfly.org/v4/charts/bullet-chart)
 > - [Victory chart documentation](https://formidable.com/open-source/victory/docs/victory-chart/)

--- a/react-charts/donut-chart/finish.md
+++ b/react-charts/donut-chart/finish.md
@@ -3,7 +3,7 @@ Congratulations! You finished the "donut chart" course.
 [Please fill out a quick survey here](https://redhatdg.co1.qualtrics.com/jfe/form/SV_bIRZRHYJyGsKBSt?Module=charts-donutchart)
 
 > Learn more about PatternFly React:
->- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/developers)
->- [PatternFly React documentation](https://www.patternfly.org/v4/documentation/react/components/)
->- [PatternFly donut chart documentation](https://patternfly-react.surge.sh/patternfly-4/charts/chartdonut/)
+>- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/develop)
+>- [PatternFly React documentation](https://www.patternfly.org/v4/charts/about)
+>- [PatternFly donut chart documentation](https://www.patternfly.org/v4/charts/donut-chart)
 >- [Victory chart documentation](https://formidable.com/open-source/victory/docs/victory-chart/)

--- a/react-charts/donut-utilization-chart/finish.md
+++ b/react-charts/donut-utilization-chart/finish.md
@@ -3,7 +3,7 @@ Congratulations! You finished the "donut utilization chart" course.
 [Please fill out a quick survey here](https://redhatdg.co1.qualtrics.com/jfe/form/SV_bIRZRHYJyGsKBSt?Module=charts-donututilizationchart)
 
 > Learn more about PatternFly React:
->- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/developers)
->- [PatternFly React documentation](https://www.patternfly.org/v4/documentation/react/components/)
->- [PatternFly donut utilization chart documentation](https://patternfly-react.surge.sh/patternfly-4/charts/chartdonututilization/)
+>- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/develop)
+>- [PatternFly React documentation](https://www.patternfly.org/v4/charts/about)
+>- [PatternFly donut utilization chart documentation](https://www.patternfly.org/v4/charts/donut-utilization-chart)
 >- [Victory chart documentation](https://formidable.com/open-source/victory/docs/victory-chart/)

--- a/react-charts/line-chart/finish.md
+++ b/react-charts/line-chart/finish.md
@@ -3,7 +3,7 @@ Congratulations! You finished the "line chart" course.
 [Please fill out a quick survey here](https://redhatdg.co1.qualtrics.com/jfe/form/SV_bIRZRHYJyGsKBSt?Module=charts-linechart)
 
 > Learn more about PatternFly React:
->- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/developers)
->- [PatternFly React documentation](https://www.patternfly.org/v4/documentation/react/components/)
->- [PatternFly line chart documentation](https://patternfly-react.surge.sh/patternfly-4/charts/chartline/)
+>- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/develop)
+>- [PatternFly React documentation](https://www.patternfly.org/v4/charts/about)
+>- [PatternFly line chart documentation](https://www.patternfly.org/v4/charts/line-chart)
 >- [Victory chart documentation](https://formidable.com/open-source/victory/docs/victory-chart/)

--- a/react-charts/pie-chart/finish.md
+++ b/react-charts/pie-chart/finish.md
@@ -3,7 +3,7 @@ Congratulations! You finished the "pie chart" course.
 [Please fill out a quick survey here](https://redhatdg.co1.qualtrics.com/jfe/form/SV_bIRZRHYJyGsKBSt?Module=charts-piechart)
 
 > Learn more about PatternFly React:
->- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/developers)
->- [PatternFly React documentation](https://www.patternfly.org/v4/documentation/react/components/)
->- [PatternFly pie chart documentation](https://patternfly-react.surge.sh/patternfly-4/charts/chartpie/)
+>- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/develop)
+>- [PatternFly React documentation](https://www.patternfly.org/v4/charts/about)
+>- [PatternFly pie chart documentation](https://www.patternfly.org/v4/charts/pie-chart)
 >- [Victory chart documentation](https://formidable.com/open-source/victory/docs/victory-chart/)

--- a/react-charts/sparkline-chart/finish.md
+++ b/react-charts/sparkline-chart/finish.md
@@ -3,7 +3,7 @@ Congratulations! You finished the "sparkline chart" course.
 [Please fill out a quick survey here](https://redhatdg.co1.qualtrics.com/jfe/form/SV_bIRZRHYJyGsKBSt?Module=charts-sparklinechart)
 
 > Learn more about PatternFly React:
->- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/developers)
->- [PatternFly React documentation](https://www.patternfly.org/v4/documentation/react/components/)
->- [PatternFly sparkline chart documentation](https://patternfly-react.surge.sh/patternfly-4/charts/sparkline/)
+>- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/develop)
+>- [PatternFly React documentation](https://www.patternfly.org/v4/charts/about)
+>- [PatternFly sparkline chart documentation](https://www.patternfly.org/v4/charts/sparkline-chart)
 >- [Victory chart documentation](https://formidable.com/open-source/victory/docs/victory-chart/)

--- a/react-charts/stack-chart/finish.md
+++ b/react-charts/stack-chart/finish.md
@@ -3,7 +3,7 @@ Congratulations! You finished the "stack chart" course.
 [Please fill out a quick survey here](https://redhatdg.co1.qualtrics.com/jfe/form/SV_bIRZRHYJyGsKBSt?Module=charts-stackchart)
 
 > Learn more about PatternFly React:
->- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/developers)
->- [PatternFly React documentation](https://www.patternfly.org/v4/documentation/react/components/)
->- [PatternFly stack chart documentation](https://patternfly-react.surge.sh/patternfly-4/charts/chartstack/)
+>- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/develop)
+>- [PatternFly React documentation](https://www.patternfly.org/v4/charts/about)
+>- [PatternFly stack chart documentation](https://www.patternfly.org/v4/charts/stack-chart/)
 >- [Victory chart documentation](https://formidable.com/open-source/victory/docs/victory-chart/)

--- a/react-components/select/finish.md
+++ b/react-components/select/finish.md
@@ -4,5 +4,5 @@ Congratulations! You finished the "select component: beginner" course.
 
 > Learn more about PatternFly React:
 >
-> - [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/developers)
-> - [PatternFly React documentation](https://www.patternfly.org/v4/documentation/react/components/table/)
+> - [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/develop)
+> - [PatternFly React documentation](https://www.patternfly.org/v4/components/select)

--- a/react-components/table-intro/finish.md
+++ b/react-components/table-intro/finish.md
@@ -3,5 +3,5 @@ Congratulations! You finished the "table component: beginner" course.
 [Please fill out a quick survey here](https://redhatdg.co1.qualtrics.com/jfe/form/SV_bIRZRHYJyGsKBSt?Module=table-introtable)
 
 > Learn more about PatternFly React:
->- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/developers)
->- [PatternFly React documentation](https://www.patternfly.org/v4/documentation/react/components/table/)
+>- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/develop)
+>- [PatternFly React documentation](https://www.patternfly.org/v4/components/table)

--- a/react-components/table-intro/step1.md
+++ b/react-components/table-intro/step1.md
@@ -102,4 +102,4 @@ const rowsDefinition = [
 ];
 </pre>
 
-Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/documentation/react/components/table/) for more information.
+Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/components/table) for more information.

--- a/react-components/table-intro/step2.md
+++ b/react-components/table-intro/step2.md
@@ -50,4 +50,4 @@ The table should now look like the image below:
 
 <img src="table-intro/assets/step-2-complete.png" alt="Image of what table looks like at the end of step 2." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
 
-Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/documentation/react/components/table/) for more information.
+Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/components/table) for more information.

--- a/react-components/table-intro/step3.md
+++ b/react-components/table-intro/step3.md
@@ -16,4 +16,4 @@ The table should visually appear exactly as it did before:
 
 Now you can see that column cell definitions can be written as basic strings, or written in object form for more advanced cases. Using object notation here is useful when you need to attach and work with arbitrary data to achieve some custom or dynamic rendering of your column cells.
 
-Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/documentation/react/components/table/) for more information.
+Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/components/table) for more information.

--- a/react-components/table-intro/step4.md
+++ b/react-components/table-intro/step4.md
@@ -66,4 +66,4 @@ The table should visually appear exactly as it did before:
 
 Now you can see how row cell definitions can be written as basic strings, or written in object form for more advanced cases. Using object notation here is useful when you need to attach and work with arbitrary data to achieve some custom or dynamic rendering of your row cells.
 
-Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/documentation/react/components/table/) for more information.
+Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/components/table) for more information.

--- a/react-components/table-intro/step5.md
+++ b/react-components/table-intro/step5.md
@@ -12,4 +12,4 @@ variant="compact"
 
 <img src="table-intro/assets/step-5-complete.png" alt="Image of what table looks like at the end of step 5." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
 
-Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/documentation/react/components/table/) for more information.
+Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/components/table) for more information.

--- a/react-components/table-intro/step6.md
+++ b/react-components/table-intro/step6.md
@@ -107,4 +107,4 @@ The table should render the same as it did before, except with a few more rows:
 
 <img src="table-intro/assets/step-6-complete.png" alt="Image of what table looks like at the end of step 6." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
 
-Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/documentation/react/components/table/) for more information.
+Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/components/table) for more information.

--- a/react-components/table-intro/step7.md
+++ b/react-components/table-intro/step7.md
@@ -26,4 +26,4 @@ itemCount={defaultRows.length}
 
 <img src="table-intro/assets/step-7-complete.png" alt="Image of what table looks like at the end of step 7." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
 
-Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/documentation/react/components/table/) for more information.
+Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/components/table) for more information.

--- a/react-components/table-intro/step8.md
+++ b/react-components/table-intro/step8.md
@@ -65,4 +65,4 @@ The rendered output should look like this:
 
 <img src="table-intro/assets/step-8-complete.png" alt="Image of what table looks like at the end of step 8." style="box-shadow: rgba(3, 3, 3, 0.2) 0px 1.25px 2.5px 0px;" />
 
-Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/documentation/react/components/table/) for more information.
+Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/components/table) for more information.

--- a/react-components/table-intro/step9.md
+++ b/react-components/table-intro/step9.md
@@ -48,4 +48,4 @@ The table should look like this:
 
 At this point, basic pagination of the table data should be in place. Nice!
 
-Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/documentation/react/components/table/) for more information.
+Still have questions? View the latest [Table documentation](https://www.patternfly.org/v4/components/table) for more information.

--- a/react-components/toolbar-filter/finish.md
+++ b/react-components/toolbar-filter/finish.md
@@ -3,5 +3,5 @@ Congratulations! You finished the "toolbar component with filter" course.
 [Please fill out a quick survey here](https://redhatdg.co1.qualtrics.com/jfe/form/SV_bIRZRHYJyGsKBSt?Module=toolbar-filter)
 
 > Learn more about PatternFly React:
->- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/developers)
->- [PatternFly React Toolbar documentation](https://www.patternfly.org/v4/documentation/react/components/toolbar/)
+>- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/develop)
+>- [PatternFly React Toolbar documentation](https://www.patternfly.org/v4/components/toolbar)

--- a/react/react-basics/finish.md
+++ b/react/react-basics/finish.md
@@ -3,5 +3,5 @@ Congratulations! You finished the "PatternFly React basics" course.
 [Please fill out a quick survey here](https://redhatdg.co1.qualtrics.com/jfe/form/SV_bIRZRHYJyGsKBSt?Module=react-components-intro)
 
 > Learn more about PatternFly React:
->- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/developers)
->- [PatternFly React documentation](https://www.patternfly.org/v4/documentation/react/components/card/)
+>- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/develop)
+>- [PatternFly React documentation](https://www.patternfly.org/v4/components/card)

--- a/react/react-customize/finish.md
+++ b/react/react-customize/finish.md
@@ -3,5 +3,5 @@ Congratulations! You finished the "customize PatternFly" course.
 [Please fill out a quick survey here](https://redhatdg.co1.qualtrics.com/jfe/form/SV_bIRZRHYJyGsKBSt?Module=react-components-advanced)
 
 > Learn more about PatternFly React:
->- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/developers)
->- [PatternFly React documentation](https://www.patternfly.org/v4/documentation/react/components/card/)
+>- [Getting started with PatternFly](https://www.patternfly.org/v4/get-started/develop)
+>- [PatternFly React documentation](https://www.patternfly.org/v4/components/card)


### PR DESCRIPTION
Closes #316 
Closes #310 
Closes #311 
Closes https://github.com/patternfly/patternfly-org/issues/2330

This PR fixes broken links throughout training modules:
- README
- links to component docs
- links to chart docs
- links to get-started/develop docs